### PR TITLE
Add multi-platform build support to GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 jobs:
-  build-and-release:
+  build-windows:
     runs-on: windows-latest
 
     steps:
@@ -44,6 +44,115 @@ jobs:
           Compress-Archive -Path snapchat-memories-downloader-windows -DestinationPath snapchat-memories-downloader-windows.zip -Force
         shell: powershell
 
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-build
+          path: dist/snapchat-memories-downloader-windows.zip
+
+  build-macos:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build dependencies
+        run: |
+          pip install -r tools/build/requirements-build.txt
+
+      - name: Build executable with PyInstaller
+        run: |
+          cd tools/build
+          pyinstaller snapchat-memories.spec
+
+      - name: Create distribution package
+        run: |
+          mkdir -p dist/snapchat-memories-downloader-macos/licenses
+          cp dist/snapchat-memories-downloader dist/snapchat-memories-downloader-macos/
+          cp docs/README-DISTRIBUTION.md dist/snapchat-memories-downloader-macos/README.md
+          cp -r docs/licenses/* dist/snapchat-memories-downloader-macos/licenses/
+          chmod +x dist/snapchat-memories-downloader-macos/snapchat-memories-downloader
+
+      - name: Create zip file
+        run: |
+          cd dist
+          zip -r snapchat-memories-downloader-macos.zip snapchat-memories-downloader-macos
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-build
+          path: dist/snapchat-memories-downloader-macos.zip
+
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build dependencies
+        run: |
+          pip install -r tools/build/requirements-build.txt
+
+      - name: Build executable with PyInstaller
+        run: |
+          cd tools/build
+          pyinstaller snapchat-memories.spec
+
+      - name: Create distribution package
+        run: |
+          mkdir -p dist/snapchat-memories-downloader-linux/licenses
+          cp dist/snapchat-memories-downloader dist/snapchat-memories-downloader-linux/
+          cp docs/README-DISTRIBUTION.md dist/snapchat-memories-downloader-linux/README.md
+          cp -r docs/licenses/* dist/snapchat-memories-downloader-linux/licenses/
+          chmod +x dist/snapchat-memories-downloader-linux/snapchat-memories-downloader
+
+      - name: Create zip file
+        run: |
+          cd dist
+          zip -r snapchat-memories-downloader-linux.zip snapchat-memories-downloader-linux
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-build
+          path: dist/snapchat-memories-downloader-linux.zip
+
+  create-release:
+    needs: [build-windows, build-macos, build-linux]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-build
+          path: artifacts
+
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-build
+          path: artifacts
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-build
+          path: artifacts
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
@@ -51,6 +160,9 @@ jobs:
           name: v${{ inputs.version }}
           draft: false
           prerelease: false
-          files: dist/snapchat-memories-downloader-windows.zip
+          files: |
+            artifacts/snapchat-memories-downloader-windows.zip
+            artifacts/snapchat-memories-downloader-macos.zip
+            artifacts/snapchat-memories-downloader-linux.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,25 +481,28 @@ The script dynamically counts and reports:
 
 ### Automated Builds with GitHub Actions
 
-The project includes a GitHub Actions workflow (`.github/workflows/release.yml`) that automatically builds and releases the Windows executable.
+The project includes a GitHub Actions workflow (`.github/workflows/release.yml`) that automatically builds and releases executables for **Windows, macOS, and Linux**.
 
 **How to create a new release:**
 
 1. Go to the repository's Actions tab on GitHub
 2. Select "Build and Release" workflow
 3. Click "Run workflow"
-4. Enter the version number (e.g., `0.1.2`)
+4. Enter the version number (e.g., `1.2.0`)
 5. Click "Run workflow"
 
 The workflow will automatically:
-- Build the Windows executable with PyInstaller
-- Create a distribution package with:
-  - `snapchat-memories-downloader.exe`
+- Build executables for **Windows**, **macOS**, and **Linux** in parallel (~5-10 minutes)
+- Create distribution packages for each platform with:
+  - Platform-specific executable
   - `README.md` (user-facing documentation)
   - `licenses/` folder (all third-party licenses)
-- Zip the distribution package
-- Create a GitHub release with the version tag (e.g., `v0.1.2`)
-- Attach the zip file to the release
+- Zip each distribution package
+- Create a GitHub release with the version tag (e.g., `v1.2.0`)
+- Attach all three platform ZIPs to the release:
+  - `snapchat-memories-downloader-windows.zip`
+  - `snapchat-memories-downloader-macos.zip`
+  - `snapchat-memories-downloader-linux.zip`
 
 **Manual Release Process:**
 

--- a/docs/BUILD-INSTRUCTIONS.md
+++ b/docs/BUILD-INSTRUCTIONS.md
@@ -232,14 +232,16 @@ chmod +x snapchat-memories-downloader
 - Build macOS executable on Windows/Linux
 - Build Linux executable on Windows/macOS
 
+**PyInstaller creates platform-specific binaries** - you must build on the target platform.
+
 ### You CAN:
+- ✅ **Use GitHub Actions** (included in this project) - builds all platforms automatically
 - Use virtual machines to build for other platforms
-- Use GitHub Actions to build all platforms automatically
 - Use cloud build services
 
-### Recommended: GitHub Actions
+### Recommended: Use the Included GitHub Actions Workflow
 
-Create `.github/workflows/build.yml` to automatically build all platforms on every release tag.
+This project includes `.github/workflows/release.yml` that automatically builds all platforms. See the "Automated Builds with GitHub Actions" section above for details.
 
 ## Size Optimization
 
@@ -271,16 +273,58 @@ Each build includes:
 - Third-party notices are accurate
 - README correctly attributes dependencies
 
-## Automated Builds (Future)
+## Automated Builds with GitHub Actions
 
-For automated multi-platform builds, consider:
+This project includes automated multi-platform builds using GitHub Actions.
 
-1. **GitHub Actions** - Free for public repos
-2. **Travis CI** - Multi-platform support
-3. **AppVeyor** - Windows builds
-4. **CircleCI** - macOS/Linux builds
+### Using the Automated Build Workflow
 
-Example GitHub Actions workflow available in separate documentation.
+The `.github/workflows/release.yml` workflow automatically builds executables for Windows, macOS, and Linux:
+
+1. **Go to GitHub Actions** in your repository
+2. **Select "Build and Release"** workflow
+3. **Click "Run workflow"**
+4. **Enter version number** (e.g., `1.2.0`)
+5. **Click "Run workflow"**
+
+The workflow will:
+- Build executables for **Windows**, **macOS**, and **Linux** in parallel
+- Package each with documentation and licenses
+- Create ZIP files for distribution
+- Create a GitHub release with tag `v{version}`
+- Attach all three platform ZIPs to the release
+
+**Build time:** ~5-10 minutes (all platforms build in parallel)
+
+**Requirements:** Public repository (free) or GitHub Pro/Team/Enterprise
+
+### What Gets Built
+
+Each platform build includes:
+- Platform-specific executable
+- `README.md` (user documentation)
+- `licenses/` folder (all third-party licenses)
+
+**Output files:**
+- `snapchat-memories-downloader-windows.zip` (~15-25 MB)
+- `snapchat-memories-downloader-macos.zip` (~15-20 MB)
+- `snapchat-memories-downloader-linux.zip` (~15-20 MB)
+
+### Advantages of GitHub Actions
+
+- ✅ **No Mac/Linux needed** - Build all platforms from Windows
+- ✅ **Free for public repos** - No cost for open source
+- ✅ **Parallel builds** - All platforms at once
+- ✅ **Reproducible** - Same build environment every time
+- ✅ **Automated releases** - ZIPs attached to GitHub releases automatically
+
+### Alternative CI Services
+
+For private repositories or other needs:
+
+1. **Travis CI** - Multi-platform support
+2. **AppVeyor** - Windows builds
+3. **CircleCI** - macOS/Linux builds
 
 ---
 


### PR DESCRIPTION
Extended GitHub Actions workflow to build executables for Windows, macOS, and Linux:

Changes to .github/workflows/release.yml:
- Split into separate jobs: build-windows, build-macos, build-linux
- Each job runs on appropriate platform runner (windows-latest, macos-latest, ubuntu-latest)
- All builds run in parallel for efficiency
- Artifacts uploaded from each platform build
- New create-release job downloads all artifacts and creates single release with all three ZIPs

Documentation updates:
- Updated CLAUDE.md Release Process section to reflect multi-platform builds
- Updated BUILD-INSTRUCTIONS.md with comprehensive GitHub Actions documentation
- Updated Cross-Platform Considerations to recommend included workflow

Benefits:
- Build macOS and Linux executables without Mac/Linux hardware
- Free for public repositories
- Automated, reproducible builds
- All platforms built in parallel (~5-10 minutes)
- Single release with all three platform packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)