### PR TITLE
Fix file paths for macOS and Linux builds in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Create distribution package
         run: |
           mkdir -p dist/snapchat-memories-downloader-macos/licenses
-          cp dist/snapchat-memories-downloader dist/snapchat-memories-downloader-macos/
+          cp tools/build/dist/snapchat-memories-downloader dist/snapchat-memories-downloader-macos/
           cp docs/README-DISTRIBUTION.md dist/snapchat-memories-downloader-macos/README.md
           cp -r docs/licenses/* dist/snapchat-memories-downloader-macos/licenses/
           chmod +x dist/snapchat-memories-downloader-macos/snapchat-memories-downloader
@@ -114,7 +114,7 @@ jobs:
       - name: Create distribution package
         run: |
           mkdir -p dist/snapchat-memories-downloader-linux/licenses
-          cp dist/snapchat-memories-downloader dist/snapchat-memories-downloader-linux/
+          cp tools/build/dist/snapchat-memories-downloader dist/snapchat-memories-downloader-linux/
           cp docs/README-DISTRIBUTION.md dist/snapchat-memories-downloader-linux/README.md
           cp -r docs/licenses/* dist/snapchat-memories-downloader-linux/licenses/
           chmod +x dist/snapchat-memories-downloader-linux/snapchat-memories-downloader


### PR DESCRIPTION
The macOS and Linux builds were failing because PyInstaller outputs to tools/build/dist/ but the packaging step was trying to copy from dist/.

Changed:
- macOS: cp dist/snapchat-memories-downloader -> cp tools/build/dist/snapchat-memories-downloader
- Linux: cp dist/snapchat-memories-downloader -> cp tools/build/dist/snapchat-memories-downloader

This matches the Windows build which correctly uses tools/build/dist/snapchat-memories-downloader.exe

Fixes GitHub Actions run #18825749674

🤖 Generated with [Claude Code](https://claude.com/claude-code)