### PR TITLE
Add permissions to workflow to fix 403 error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write  # Required for creating releases and tags
+
 jobs:
   build-windows:
     runs-on: windows-latest


### PR DESCRIPTION
GitHub Actions workflows need explicit permissions to create releases. Added 'contents: write' permission to allow the workflow to:
- Create GitHub releases
- Create tags
- Upload release assets

This fixes the 403 Forbidden error encountered in run #18825840772.

Without this permission, the default GITHUB_TOKEN has read-only access and cannot create releases, even though the token is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)