### PR TITLE
Skip GPS Metadata writing for blank coordinates (0,0)

### DIFF
--- a/scripts/metadata.py
+++ b/scripts/metadata.py
@@ -113,6 +113,11 @@ def add_gps_metadata(file_path: Path, memory: Dict, has_exiftool: bool):
         return
 
     lat, lon = coords
+    
+    # Skip if coordinates are (0,0) - those are blank and should not be written to the file.
+    if lat == 0.0 and lon == 0.0:
+        return
+    
     file_ext = file_path.suffix.lower()
 
     # Only process media files (skip overlays which are PNGs without location context)


### PR DESCRIPTION
Adds a check to avoid writing blank coordinates to the metadata. 

This speeds up the whole script by avoiding unnecessary calls to exiftool (1.5s per call) and prevents media from being located to the middle of the ocean when snapchat does not provide location data (Latitude, Longitude: 0.0, 0.0).